### PR TITLE
Saving new listing

### DIFF
--- a/app/controllers/api/listings_controller.rb
+++ b/app/controllers/api/listings_controller.rb
@@ -78,16 +78,16 @@ class Api::ListingsController < ApplicationController
   private
     def listing_params
       params.require(:listing).permit(
-        :user_id, :title, :thumb_img_idx, 
-        :address, :lat, :lng, :price, :home_type_id, 
-        :description, :max_guests, photos: [], amenity_ids: [], listing_availabilities: [:start_date, :end_date]
+        :user_id, :title, :thumb_img_idx,
+        :address, :lat, :lng, :price, :home_type_id,
+        :description, :max_guests, photos: [], amenity_ids: [], listing_availabilities_attributes: [:start_date, :end_date]
       )
    end
 
    def listing_availabilities_params
     params.require(:listing).permit(:start_date, :end_date)
   end
-  
+
    def query_params
     params[:query] if params[:query]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,9 @@ Rails.application.routes.draw do
     post '/bookings/ids', to: 'bookings#index'
     get '/listings/:listing_id/bookings', to: 'bookings#index'
     patch '/bookings/:id/:status', to: 'bookings#update_status'
-    
   end
+
+  get '/undefined', to: 'static_pages#root'
+
   root to: 'static_pages#root'
 end


### PR DESCRIPTION
# Saving the Listing
Addressing issue https://github.com/joycemap/JoyceStay/issues/13

When using nested attributes, the params naming for associated models ends in `_attributes` to have Rails recognize that you're including an association and convert the value of that key to a constructor for the associated model (i.e, `ListingAvailability`). here is an example from the docs

https://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html#module-ActiveRecord::NestedAttributes::ClassMethods-label-One-to-many

To break down the error message a bit: 
`ActiveRecord::AssociationTypeMismatch - ListingAvailability(#70351374301020) expected, got ["start_date", ""]`

It's reasonable to think about creating a listing like this

```rb
listing_availability = ListingAvailability.create(...)
listing = Listing.new(user_id: 'blah', listing_availabilities: [listing_availability], ...<other_args>)
listing.save
```

Rails is expecting the key `listing_availabilities` to be a collection of `ListingAvailability` since it's `has_many`.

But in the case in this controller, the Listing.new was receiving a collection of two element arrays since the params were defined `listing_availabilities: [:start_date, :end_date]`.

As mentioned, we're looking for Rails to do some magic to use the values from the params specific for listing availabilities to first instantiate a collection of `ListingAvailability` before using them as values for creating the `Listing`, we need to use the special `_attributes` suffix in the strong params definition. 

# Redirect on Success
Once that was fixed, i was seeing `Started GET "/undefined" for ::1 at 2020-07-13 14:01:52 -0500` in the logs. I updated the routes to send that request to your static root as well. 
