### PR TITLE
Edit dates for update

### DIFF
--- a/frontend/components/listings/listing_form.jsx
+++ b/frontend/components/listings/listing_form.jsx
@@ -67,10 +67,7 @@ class ListingForm extends Component {
 
   checkBlockedDays = (day) => {
     if (this.props.listing) {
-      const {
-        listing,
-        listing: { booked_dates },
-      } = this.props;
+      const { listing: { booked_dates } } = this.props;
       day = moment(day).format("YYYY-MM-DD");
 
       return (
@@ -82,9 +79,7 @@ class ListingForm extends Component {
               null,
               "()"
             ) && booking.status == "APPROVED"
-        ).length ||
-        moment(day).isBefore(moment(listing.start_date).subtract(1, "d")) ||
-        moment(day).isAfter(listing.end_date)
+        ).length
       );
     }
   };
@@ -146,7 +141,6 @@ class ListingForm extends Component {
   };
 
   handleSubmit = () => {
-    debugger;
     const { hasErrors, fieldErrors } = this.checkForEmptyFields();
     this.setState({ savingListing: true });
 

--- a/frontend/components/listings/listing_form.jsx
+++ b/frontend/components/listings/listing_form.jsx
@@ -224,8 +224,7 @@ class ListingForm extends Component {
       "start_date",
       "end_date",
       "max_guests",
-      "home_type_id",
-      "photos",
+      "home_type_id"
     ];
 
     const fieldErrors = {};


### PR DESCRIPTION
This addresses https://github.com/joycemap/JoyceStay/issues/4

This issue has multiple considerations

I addressed these:

- it was only allowing changes to dates _within_ the original window defined (wouldn't be able to add a day to the listing only reduce the number of days).... i dunno if that was intentional or not, so feel free to change back lines 86 and 87. 
- the form couldn't be saved regardless of the dates if no photos were added to the update as well (it was checking for whether the photos field was blank for validation).

the last one requires some thought on how you want the functionality to work, i don't think you should change the fact that its readonly.

- I assume the fields are readonly to make things easier. With the selecting ranges option through the picker, the user can see what dates they have to pick from (by whether or not the date is available for selecting). If you allowed direct input into those text fields, you would have to validate that the input date is 

  1. a valid date format (since the field isn't a 'date' type, its text)
  2. a valid available date: not before today, after the start date if it's the end date, not across multiple availabilities, and not on or between something already booked)...thats a lot of logic that the date range picker is already designed to deal with.

the idea is the clicking the date field _opens_ the range input...the fields are just for displaying the result of your selection and recording it as a form value for serializing to the backend.

Does that make sense?